### PR TITLE
use timer_setup with later kernels

### DIFF
--- a/rtbth_hlpr_linux.c
+++ b/rtbth_hlpr_linux.c
@@ -425,7 +425,11 @@ INT ral_timer_init(
 	os_timer->pOSTimer = kmalloc(sizeof(struct timer_list), GFP_KERNEL);
 	if (os_timer->pOSTimer) {
 		timer = os_timer->pOSTimer;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
+		timer_setup(timer, (void *)func, (unsigned long)os_timer);
+#else
 		setup_timer(timer, (void *)func, (unsigned long)os_timer);
+#endif
 		ral_spin_lock(&os_timer->lock, &irqflags);
 		os_timer->state = RES_VALID;
 		ral_spin_unlock(&os_timer->lock, irqflags);


### PR DESCRIPTION
Because Linux removed setup_timer macros for kernel version >= 4.15
[Linux: 513ae785c63c ("timer: Remove setup_*timer() interface")](https://github.com/torvalds/linux/commit/513ae785c63c30741e46f43960213d4ae5382ec0)