### PR TITLE
Fix for pairing on 16.04

### DIFF
--- a/rtbth_core_us.c
+++ b/rtbth_core_us.c
@@ -1839,9 +1839,13 @@ long    rtbth_us_unlocked_ioctl(struct file *filp, unsigned int cmd, unsigned lo
 
                 if(dmac.dmac_op == 0){
                     RtbtResetPDMA(gpAd);
-                }else if(dmac.dmac_op == 1){
+                }
+		    
+		if(dmac.dmac_op == 1){
                     BthEnableRxTx(gpAd);
-                }else if(dmac.dmac_op == 2){
+                }
+		
+		if(dmac.dmac_op == 2){
                     DebugPrint(TRACE, DBG_MISC, "%s:kfifo reset ==>\n", __func__);
                     kfifo_reset(gpAd->acl_fifo);
                     kfifo_reset(gpAd->hci_fifo);


### PR DESCRIPTION
Fix for pairing on 16.04 with RTBTH_IOCDMAC: dmac.dmac_op=2
Pairs with LE and Bluetooth V3 devices as well. Tested on Ubuntu 16.04 with RT3290 Bluetooth adapter and T2 headset and Lenovo Android phone.

Please test on other systems.