### PR TITLE
Fix error in  PR #9

### DIFF
--- a/rtbth_hlpr_linux.c
+++ b/rtbth_hlpr_linux.c
@@ -376,7 +376,7 @@ BOOLEAN KeCancelTimer(
 
 	ral_spin_lock(&os_timer->lock, &irqflags);
 	if (os_timer->pOSTimer && (os_timer->state == RES_VALID)) {
-    #ifdef timer_shutdown_sync
+    #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,15,0)
       status = timer_shutdown_sync((struct timer_list *)os_timer->pOSTimer);
     #else
       status = del_timer_sync((struct timer_list *)os_timer->pOSTimer);
@@ -404,7 +404,7 @@ INT KeFreeTimer(
 	if (os_timer->pOSTimer) {
 		timer = (struct timer_list *)os_timer->pOSTimer;
 		if (timer_pending(timer))
-    #ifdef timer_shutdown_sync
+    #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,15,0)
       timer_shutdown_sync(timer);
     #else
       del_timer_sync(timer);


### PR DESCRIPTION
fix error #9
I realized my previous fix using `ifdef timer_shutdown_sync` caused issues and always ran the `else` condition.
I’ve updated it to check the kernel version properly, and it’s now compiling correctly.
I apologize for the oversight and any inconvenience caused.

https://github.com/loimu/rtbth-dkms/blob/bc84818f19928aca28aa0d52451c7ed4f4e8b6a4/rtbth_hlpr_linux.c#L379-L383